### PR TITLE
(feat.) ParameterSeparatorValue should be displayed in job's parameters page

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,17 +42,24 @@
 		</plugins>
 	</build>
 
-	<distributionManagement>
-		<repository>
-			<id>maven.jenkins-ci.org</id>
-			<url>http://maven.jenkins-ci.org/content/repositories/releases/</url>
-		</repository>
-	</distributionManagement>
-
 	<scm>
 		<connection>scm:git:ssh://github.com/jenkinsci/parameter-separator-plugin.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/jenkinsci/parameter-separator-plugin.git</developerConnection>
 		<url>https://github.com/jenkinsci/parameter-separator-plugin</url>
 	  <tag>HEAD</tag>
-  </scm>
+	</scm>
+	<!-- save the effort that configuration in %MAVEN_HOME%/conf/settings.xml -->
+	<repositories>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</repository>
+	</repositories>
+
+	<pluginRepositories>
+		<pluginRepository>
+			<id>repo.jenkins-ci.org</id>
+			<url>http://repo.jenkins-ci.org/public/</url>
+		</pluginRepository>
+	</pluginRepositories>
 </project>

--- a/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorDefinition.java
+++ b/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorDefinition.java
@@ -109,18 +109,20 @@ public class ParameterSeparatorDefinition extends ParameterDefinition {
     @Override
     public ParameterValue getDefaultParameterValue() {
         // TODO: Should load a default, not hard-code it
-        return new ParameterSeparatorValue(getName(), "");
+        return new ParameterSeparatorValue(getName()
+        								, getComputedSeparatorStyle()
+        								, getSectionHeader()
+        								, getSectionHeaderStyle());
     }
 
     @Override
     public ParameterValue createValue(final StaplerRequest request) {
-        String[] requestFields = request.getParameterValues(getName());
-        return new ParameterSeparatorValue(getName(), "");
+        return getDefaultParameterValue();
     }
 
     @Override
     public ParameterValue createValue(final StaplerRequest request, final JSONObject jObj) {
-        return new ParameterSeparatorValue(getName(), "");
+        return getDefaultParameterValue();
     }
 
     @Override

--- a/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
+++ b/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
@@ -7,13 +7,53 @@
 package jenkins.plugins.parameter_separator;
 
 import org.kohsuke.stapler.DataBoundConstructor;
-import hudson.model.StringParameterValue;
+import hudson.model.ParameterValue;
 
-public class ParameterSeparatorValue extends StringParameterValue {
+public class ParameterSeparatorValue extends ParameterValue {
 
+	private String separatorStyle = "";
+    private String sectionHeader = "";
+    private String sectionHeaderStyle = "";
+
+    public String getSectionHeader() {
+        return sectionHeader;
+    }
+
+    public void setSectionHeader(final String sh) {
+        this.sectionHeader = sh;
+    }
+
+    public String getSectionHeaderStyle() {
+        return sectionHeaderStyle;
+    }
+
+    public void setSectionHeaderStyle(final String shs) {
+        this.sectionHeaderStyle = shs;
+    }
+
+     public String getSeparatorStyle() {
+        return separatorStyle;
+    }
+	
     @DataBoundConstructor
-    public ParameterSeparatorValue(final String name, final String value) {
-        super(name, value);
+    public ParameterSeparatorValue(final String name
+    							, final String separatorStyle
+    							, final String sectionHeader
+    							, final String sectionHeaderStyle
+    							) {
+        super(name, "");
+        this.separatorStyle = separatorStyle;
+        this.sectionHeader = sectionHeader;
+        this.sectionHeaderStyle = sectionHeaderStyle;
+    }
+    
+    @Override
+    public String toString() {
+    	return "(ParameterSeparatorValue) " + getName();
+    }
 
+    @Override 
+    public String getShortDescription() {
+        return getName();
     }
 }

--- a/src/main/resources/jenkins/plugins/parameter_separator/ParameterSeparatorValue/value.jelly
+++ b/src/main/resources/jenkins/plugins/parameter_separator/ParameterSeparatorValue/value.jelly
@@ -1,15 +1,8 @@
-<!--
- Copyright (c) 2014 Mike Chmielewski
- See the file license.txt for copying permission. 
--->
 
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
   xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
   xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
   <f:entry title="" description="">
-	<div name="parameter">
-		<input type="hidden" name="name" value="${it.name}" />
-	</div>
     <hr style="${it.computedSeparatorStyle}" />
     <j:if test="${it.sectionHeader != null and it.sectionHeader != ''}">
     <div style="${it.sectionHeaderStyle}">${it.sectionHeader}</div>


### PR DESCRIPTION
Although this plugin is acting like a placeholder, I think it should still accomplish the `semantics` of being a parameter both in trigger and parameter pages.

Especially for the jobs parameter page, we can review the build status with the separators with this feature in the future .

Build Trigger page:
![trigger_build_page](https://cloud.githubusercontent.com/assets/1177332/12376868/f244f310-bd43-11e5-931e-3a1e48ac1b43.png)

Parameter page for review
![build_parameter_page](https://cloud.githubusercontent.com/assets/1177332/12376870/f561967a-bd43-11e5-8d7a-915a6c4b3241.png)

