### PR TITLE
JENKINS-41712: Overriding getValue()

### DIFF
--- a/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
+++ b/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
@@ -58,7 +58,7 @@ public class ParameterSeparatorValue extends ParameterValue {
     }
 
     @Override
-    public Object getValue() {
+    public String getValue() {
         return toString();
     }
 }

--- a/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
+++ b/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
@@ -57,7 +57,7 @@ public class ParameterSeparatorValue extends ParameterValue {
         return getName();
     }
 
-    @Override
+    @Nonnull
     public String getValue() {
         return toString();
     }

--- a/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
+++ b/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
@@ -56,4 +56,9 @@ public class ParameterSeparatorValue extends ParameterValue {
     public String getShortDescription() {
         return getName();
     }
+
+    @Override
+    public Object getValue() {
+        return toString();
+    }
 }

--- a/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
+++ b/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorValue.java
@@ -57,7 +57,6 @@ public class ParameterSeparatorValue extends ParameterValue {
         return getName();
     }
 
-    @Nonnull
     public String getValue() {
         return toString();
     }


### PR DESCRIPTION
Based on bug, we should not return null, so we are returning toString() result instead.