### PR TITLE
Make separator usable from declarative pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,11 @@
 	</developers>
 
 	<dependencies>
+		<dependency>
+			<groupId>org.jenkins-ci</groupId>
+			<artifactId>symbol-annotation</artifactId>
+			<version>1.14</version>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorDefinition.java
+++ b/src/main/java/jenkins/plugins/parameter_separator/ParameterSeparatorDefinition.java
@@ -13,6 +13,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParameterDefinition;
 import hudson.util.FormValidation;
 
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.*;
 
 import com.google.common.base.Strings;
@@ -22,6 +23,7 @@ import net.sf.json.JSONObject;
 public class ParameterSeparatorDefinition extends ParameterDefinition {
 
     @Extension
+    @Symbol("separator")
     public static class ParameterSeparatorDescriptor extends ParameterDescriptor {
 
         private String globalSeparatorStyle = "";


### PR DESCRIPTION
Declarative pipeline requires extensions to be loaded via their symbol.
The new dependency only contains a single class and is also available by
default in Jenkins 2.X. We can also modify the dependency to point to an older version of the symbol-annotation artifacts or the structs-plugin to prevent dependency issues for users.